### PR TITLE
Add ability to copy current url and title as org mode

### DIFF
--- a/docs/docs/tutorial/clipboard.md
+++ b/docs/docs/tutorial/clipboard.md
@@ -11,6 +11,7 @@ sidebar_label: Clipboard
 You can copy the current page's URL, or you can use link hints to copy the URL of a link on screen.
 
 * **Copy Current URL** - <kbd>y</kbd><kbd>y</kbd>
+* **Copy Current Url and Title as Org-Mode** - <kbd>y</kbd><kbd>o</kbd>
 * **Copy URL Using Link Hints** - coming soon
 
 You can then _activate_ the clipboard. If the clipboard contains a URL, this will navigate to the URL. Otherwise, this will perform a search.

--- a/src/modes/command/client/commands/clipboard.js
+++ b/src/modes/command/client/commands/clipboard.js
@@ -4,6 +4,18 @@ import { background } from 'lib/msg'
 export const copyURL = () => {
   copy(document.location.href)
 }
+
+export const copyToORG = () => {
+  function elideTitle () {
+    if (document.title.length > 80) {
+      return document.title.substr(0, 80 - 3).concat('...')
+    } else {
+      return document.title
+    }
+  }
+  copy('[[' + document.location.href + '][' + elideTitle() + ']]')
+}
+
 export const clipboardCurrentTab = background('clipboardCurrentTab')
 export const clipboardBackgroundTab = background('clipboardBackgroundTab')
 export const clipboardForegroundTab = background('clipboardForegroundTab')

--- a/src/options/Keybindings/config.json
+++ b/src/options/Keybindings/config.json
@@ -468,6 +468,12 @@
     },
     {
       "type": "keybinding",
+      "label": "Copy Current ORG",
+      "key": "copyToORG",
+      "default": []
+    },
+    {
+      "type": "keybinding",
       "label": "Activate Clipboard in Current Tab",
       "key": "clipboardCurrentTab",
       "default": []

--- a/src/options/Keybindings/default.json
+++ b/src/options/Keybindings/default.json
@@ -188,6 +188,9 @@
         "copyURL": [
           [{ "code": "KeyY", "key": "y" }, { "code": "KeyY", "key": "y" }]
         ],
+        "copyToORG": [
+          [{ "code": "KeyY", "key": "y" }, { "code": "KeyO", "key": "o" }]
+        ],
         "clipboardCurrentTab": [
           [{ "code": "KeyY", "key": "y" }, { "code": "KeyF", "key": "f" }]
         ],


### PR DESCRIPTION
I find saka `yy` as copy url to clipboard very handy. But most of the time, thousands times a day  I had to copy url and title to org-mode format. So I add this addition to make my life easier.

- This will copy current url and page title as org-mode format to system clipboard. if page title more than 80 characters, replace them with '...'. This also can be customizable via saka-key setting, but I don't have any idea where to put that field, I don't think appearance tab is suitable place for `title max length` field.

