### PR TITLE
NOT READY: New Firefox duplicate background tab fix + version check

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -62,6 +62,8 @@ export function deepActiveElement (root = document) {
     : activeElement
 }
 
+const firefoxAgentMatch = navigator.userAgent.match(/\bFirefox\/(\d+)/)
+
 /**
  * Dispatch a mouse event to the target element
  * based on cVim's implementation
@@ -79,7 +81,12 @@ export function mouseEvent (element, type, modifierKeys = {}) {
       events = ['mousemove', 'mouseout', 'mouseleave']
       break
     case 'click':
-      events = ['mouseover', 'mousedown', 'mouseup', 'click']
+      // If FF >= 96, skip extraneous click event (causes duplicate tabs).
+      if (firefoxAgentMatch && parseInt(firefoxAgentMatch[1]) >= 96) {
+        events = ['mouseover', 'mousedown', 'mouseup']
+      } else {
+        events = ['mouseover', 'mousedown', 'mouseup', 'click']
+      }
       break
   }
   events.forEach(type => {


### PR DESCRIPTION
A simple fix for the duplicate background tabs problem happening since about Firefox 96, according to [this Vimium commit](https://github.com/philc/vimium/pull/3985/commits/cf420fbc31348db3db1002b1d5aab6051f9f0a9b).

This disables the extra `click` event for Firefox >= 96. ~~However, on Arch Linux (which has the latest Firefox), with Firefox 96, the user agent string is still showing as Firefox 91. So the version check is incorrect. I'm not certain if this happens on more peoples' machines than mine.~~ The reason it did not work for me was because `privacy.resistFingerprinting` was set to `true`. Need a workaround for this.